### PR TITLE
Compile on CPU  by default if no CUDA device

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ libraries = ['minkowski']
 # extra_compile_args+=['-g']  # Uncomment for debugging
 if CPU_ONLY:
     print('\nCPU_ONLY build')
-    argv.remove('--cpu_only')
+    if '--cpu_only' in argv:
+        argv.remove('--cpu_only')
     compile_args += ['CPU_ONLY=1']
     extra_compile_args += ['-DCPU_ONLY']
     Extension = CppExtension

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def run_command(*args):
 
 
 # For cpu only build
-CPU_ONLY = '--cpu_only' in argv
+CPU_ONLY = '--cpu_only' in argv or not torch.cuda.is_available()
 KEEP_OBJS = '--keep_objs' in argv
 BLAS = [arg for arg in argv if '--blas' in arg]
 


### PR DESCRIPTION
Hi,
It would be nice to have cpu only mode by default when the platform does not have a CUDA device, this PR introduces the change.
Let me know if you'd like me to amend the doc, I think it is ok as it is.
Best,
Nicolas