### PR TITLE
hide memory copy and computation latency as well as fewer threads using by ILP(instruction-level parallel)

### DIFF
--- a/src/convolution.cu
+++ b/src/convolution.cu
@@ -113,13 +113,10 @@ __global__ void matmul(const Dtype *A, const int wA, const int hA,
 
   // Write the block sub-matrix to device memory;
   // each thread writes one element
-  //if (y < hA && x < wB)
-  //  atomicAdd(&C[wB * out_row + x], Csub);
-  // C[wB * out_row + x] += Csub;
 #pragma unroll
   for (int ilp = 0; ilp < NumILP; ++ilp) {
     if (ilp * step + y < hA && x < wB)
-      C[wB * out_row[ilp] + x] = Csub[ilp];
+      atomicAdd(&C[wB * out_row[ilp] + x], Csub[ilp]);
   }
 }
 

--- a/src/convolution.cu
+++ b/src/convolution.cu
@@ -87,8 +87,10 @@ __global__ void matmul(const Dtype *A, const int wA, const int hA,
 #pragma unroll
     for (int ilp = 0; ilp < NumILP; ++ilp) {
       const int ilp_ty = ilp * step + ty;
-      As[ilp_ty][tx] = ((s + tx) < wA && ilp_y < hA) ? A[wA * in_row[ilp] + s + tx] : 0;
-      Bs[ilp_ty][tx] = ((s + ilp_ty) < hB && x < wB) ? B[wB * (s + ilp_ty) + x] : 0;
+      As[ilp_ty][tx] = ((s + tx) < wA && ilp * step + y < hA) ?
+                                        A[wA * in_row[ilp] + s + tx] : 0;
+      Bs[ilp_ty][tx] = ((s + ilp_ty) < hB && x < wB) ?
+                                        B[wB * (s + ilp_ty) + x] : 0;
     }
 
     // Synchronize to make sure the matrices are loaded

--- a/src/convolution.cu
+++ b/src/convolution.cu
@@ -65,8 +65,8 @@ __global__ void matmul(const Dtype *A, const int wA, const int hA,
 #pragma unroll
   for (int ilp = 0; ilp < NumILP; ++ilp) {
     int ilp_y = ilp * step + y;
-    in_row[ilp] = y < hA ? in_map[ilp_y] : 0;
-    out_row[ilp] = y < hA ? out_map[ilp_y] : 0;
+    in_row[ilp] = ilp_y < hA ? in_map[ilp_y] : 0;
+    out_row[ilp] = ilp_y < hA ? out_map[ilp_y] : 0;
     Csub[ilp] = 0;
   }
 
@@ -87,7 +87,7 @@ __global__ void matmul(const Dtype *A, const int wA, const int hA,
 #pragma unroll
     for (int ilp = 0; ilp < NumILP; ++ilp) {
       const int ilp_ty = ilp * step + ty;
-      As[ilp_ty][tx] = ((s + tx) < wA && y < hA) ? A[wA * in_row[ilp] + s + tx] : 0;
+      As[ilp_ty][tx] = ((s + tx) < wA && ilp_y < hA) ? A[wA * in_row[ilp] + s + tx] : 0;
       Bs[ilp_ty][tx] = ((s + ilp_ty) < hB && x < wB) ? B[wB * (s + ilp_ty) + x] : 0;
     }
 


### PR DESCRIPTION
hide memory copy and computation latency as well as fewer threads using by ILP(instruction-level parallel)
`NumILP` can be further tune.